### PR TITLE
Handle nullable Level in `ItemPropertyFunction`.

### DIFF
--- a/fabric/src/main/java/dev/worldgen/trimmable/tools/TrimmableToolsFabric.java
+++ b/fabric/src/main/java/dev/worldgen/trimmable/tools/TrimmableToolsFabric.java
@@ -17,6 +17,7 @@ public class TrimmableToolsFabric implements ClientModInitializer {
         TrimmableToolsClient.init();
 
         ItemProperties.registerGeneric(TrimmableToolsClient.TRIM_PATTERN, (stack, world, entity, seed) -> {
+            if (world == null) return Float.NEGATIVE_INFINITY;
             Optional<ArmorTrim> trim = ArmorTrim.getTrim(world.registryAccess(), stack);
             if (trim.isEmpty()) return Float.NEGATIVE_INFINITY;
 
@@ -25,6 +26,7 @@ public class TrimmableToolsFabric implements ClientModInitializer {
         });
 
         ItemProperties.registerGeneric(TrimmableToolsClient.TRIM_MATERIAL, (stack, world, entity, seed) -> {
+            if (world == null) return Float.NEGATIVE_INFINITY;
             Optional<ArmorTrim> trim = ArmorTrim.getTrim(world.registryAccess(), stack);
             if (trim.isEmpty()) return Float.NEGATIVE_INFINITY;
 

--- a/forge/src/main/java/dev/worldgen/trimmable/tools/forge/TrimmableToolsForge.java
+++ b/forge/src/main/java/dev/worldgen/trimmable/tools/forge/TrimmableToolsForge.java
@@ -29,6 +29,7 @@ public class TrimmableToolsForge {
             TrimmableToolsClient.init();
 
             ItemProperties.registerGeneric(TrimmableToolsClient.TRIM_PATTERN, (stack, world, entity, seed) -> {
+                if (world == null) return Float.NEGATIVE_INFINITY;
                 Optional<ArmorTrim> trim = ArmorTrim.getTrim(world.registryAccess(), stack);
                 if (trim.isEmpty()) return Float.NEGATIVE_INFINITY;
 
@@ -37,6 +38,7 @@ public class TrimmableToolsForge {
             });
 
             ItemProperties.registerGeneric(TrimmableToolsClient.TRIM_MATERIAL, (stack, world, entity, seed) -> {
+                if (world == null) return Float.NEGATIVE_INFINITY;
                 Optional<ArmorTrim> trim = ArmorTrim.getTrim(world.registryAccess(), stack);
                 if (trim.isEmpty()) return Float.NEGATIVE_INFINITY;
 


### PR DESCRIPTION
Currently the registered `ItemPropertyFunction`s call `Level#registryAccess` without checking if the level is `null`.
This will lead to NPE if the supplied level is `null`.
I encountered this when inserting an iron sword into a Create Depot.
The way I fixed it will probably mean that trims won't show up if the level is `null`, but I don't know of a better way to fix that, since `RegistryAccess#EMPTY` will lead to the same result.